### PR TITLE
add sha256 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,19 +9,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "imt"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "generic-array",
  "serde",
+ "sha2",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "proc-macro2"
@@ -62,6 +124,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,7 +155,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["circuits"]
+default = ["circuits", "tiny-keccak"]
 circuits = []
-
+tiny-keccak = ["dep:tiny-keccak"]
+sha2 = ["dep:sha2", "dep:generic-array"]
 
 [dependencies]
 anyhow = "1.0.86"
 serde = { version = "1.0.205", features = ["derive"] }
-tiny-keccak = { version = "2.0.2", features = ["keccak"] }
+sha2 = { version = "0.10.8", optional = true }
+tiny-keccak = { version = "2.0.2", features = ["keccak"], optional = true }
+generic-array = { version = "0.14", optional = true }

--- a/src/circuits/imt.rs
+++ b/src/circuits/imt.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use tiny_keccak::{Hasher, Keccak};
 
 use crate::{
     circuits::{
@@ -177,15 +176,15 @@ impl<H: Hashor, K: Key, V: Value> Imt<H, K, V> {
             let mut hasher = hasher_factory();
             match (left, right) {
                 (None, None) => unreachable!(),
-                (None, Some(right)) => hasher.update(&right),
-                (Some(left), None) => hasher.update(&left),
+                (None, Some(right)) => hasher.update_hashor(&right),
+                (Some(left), None) => hasher.update_hashor(&left),
                 (Some(left), Some(right)) => {
-                    hasher.update(&left);
-                    hasher.update(&right);
+                    hasher.update_hashor(&left);
+                    hasher.update_hashor(&right);
                 }
             };
 
-            hasher.finalize(&mut hash);
+            hasher.finalize_hashor_into(&mut hash);
 
             index /= 2;
 
@@ -199,10 +198,10 @@ impl<H: Hashor, K: Key, V: Value> Imt<H, K, V> {
         self.root = {
             let mut root_hash = [0; 32];
 
-            let mut k = Keccak::v256();
-            k.update(&hash);
-            k.update(&self.size.to_be_bytes());
-            k.finalize(&mut root_hash);
+            let mut k = hasher_factory();
+            k.update_hashor(&hash);
+            k.update_hashor(&self.size.to_be_bytes());
+            k.finalize_hashor_into(&mut root_hash);
 
             root_hash
         };

--- a/src/circuits/insert.rs
+++ b/src/circuits/insert.rs
@@ -72,7 +72,7 @@ impl<K: Key, V: Value> IMTInsert<K, V> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "tiny-keccak"))]
 mod tests {
     use tiny_keccak::Keccak;
 

--- a/src/circuits/mod.rs
+++ b/src/circuits/mod.rs
@@ -31,23 +31,23 @@ fn imt_root<H: Hashor, K: Key, V: Value>(
         let mut hasher = hasher_factory();
         match (left, right) {
             (None, None) => unreachable!(),
-            (None, Some(right)) => hasher.update(right),
-            (Some(left), None) => hasher.update(left),
+            (None, Some(right)) => hasher.update_hashor(right),
+            (Some(left), None) => hasher.update_hashor(left),
             (Some(left), Some(right)) => {
-                hasher.update(left);
-                hasher.update(right);
+                hasher.update_hashor(left);
+                hasher.update_hashor(right);
             }
         };
 
-        hasher.finalize(&mut hash);
+        hasher.finalize_hashor_into(&mut hash);
 
         index /= 2;
     }
 
     let mut hasher = hasher_factory();
-    hasher.update(&hash);
-    hasher.update(&size.to_be_bytes());
-    hasher.finalize(&mut hash);
+    hasher.update_hashor(&hash);
+    hasher.update_hashor(&size.to_be_bytes());
+    hasher.finalize_hashor_into(&mut hash);
 
     hash
 }

--- a/src/circuits/update.rs
+++ b/src/circuits/update.rs
@@ -53,7 +53,7 @@ impl<K: Key, V: Value> IMTUpdate<K, V> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "tiny-keccak"))]
 mod tests {
     use tiny_keccak::Keccak;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@
 #[cfg(feature = "circuits")]
 pub mod circuits;
 
+#[cfg(feature = "circuits")]
 type Hash = [u8; 32];


### PR DESCRIPTION
This is a breaking change because the `Hashor` trait changed to a new one from referencing the `tiny_keccak::Hasher`, and can't feasibly blanket all of the other hash implementations. I also made the trait have a very similar to that trait, to keep changes minimal across the crate. Happy to update anything if you'd prefer this support another way!